### PR TITLE
removing duplicate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "run-sequence": "^1.1.5",
-    "supertest": "^1.2.0",
-    "glob": "^7.0.3"
+    "supertest": "^1.2.0"
   },
   "engines": {
     "node": ">= 4.2.4"


### PR DESCRIPTION
`glob` was listed in both dependencies and devDependencies, causing npm to log a warning during install.